### PR TITLE
Update isr_wrapper.S

### DIFF
--- a/arch/arm/core/aarch64/isr_wrapper.S
+++ b/arch/arm/core/aarch64/isr_wrapper.S
@@ -46,12 +46,16 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	bl	z_soc_irq_get_active
 #endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
 	stp	x0, x1, [sp, #-16]!
+	cmp x0, #CONFIG_NUM_IRQS
+	b.hi spr
 	lsl	x0, x0, #4 /* table is 16-byte wide */
 
 	/* Retrieve the interrupt service routine */
 	ldr	x1, =_sw_isr_table
 	add	x1, x1, x0
 	ldp	x0, x3, [x1] /* arg in x0, ISR in x3 */
+	cmp	x3, #0x0
+	b.eq spr
 
 	/*
 	 * Call the ISR. Unmask and mask again the IRQs to support nested
@@ -61,6 +65,7 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	blr	x3
 	msr	daifset, #(DAIFSET_IRQ)
 
+spr:
 	/* Signal end-of-interrupt */
 	ldp	x0, x1, [sp], #16
 #if !defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)


### PR DESCRIPTION
Add checking of vector number and pointer to ISR. 

We have encountered special purpose interrupts in range of interrupt IDs  1020 up to 1023. 
At the same time the table “ _sw_isr_table” created for 240 interrupts. We should check that GIC rises interrupt ID not greater than defined by CONFIG_NUM_IRQS. 
In our case the ISR routine pointed to NULL, so we need to check if ISR callback in _sw_isr_table is not NULL.
